### PR TITLE
default export and  outputs es5/umd (main) and es5/esm (module)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ jspm_packages
 .node_repl_history
 
 # build output
-*.js
-*.map
-*.d.ts
+esri-loader.js
+src/*.js
+src/*.map
+src/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -35,7 +35,3 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
-
-# TypeScript source
-src/*.ts
-!src/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -37,5 +37,5 @@ jspm_packages
 .node_repl_history
 
 # TypeScript source
-*.ts
-!*.d.ts
+src/*.ts
+!src/*.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# esri-loader Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+### Added
+- add default export
+
+### Fixed
+- build outputs es5/umd (main) and es5/esm (module)
+
+## 0.2.0
+
+### Added
+- enable pre-loading the ArcGIS API
+- default to version 4.3 of the ArcGIS API
+
+## 0.1.3
+
+### Fixed
+- default to version 4.2 of the ArcGIS API
+- use HTTPS by default
+
+## 0.1.2
+
+### Fixed
+- finally got `import from 'esri-loader' working from Angular/TS apps
+
+## 0.1.1
+
+### Fixed
+- try to fix Error: Cannot find module "." in consuming TS apps
+
+## 0.1.0
+
+### Added
+- copied over source from angular-cli-esri and set up TS build

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "esri-loader",
   "version": "0.2.0",
   "description": "A tiny library to help load ArcGIS API for JavaScript modules in non-Dojo applications",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "esri-loader.js",
+  "module": "src/esri-loader.js",
+  "types": "src/esri-loader.d.ts",
   "scripts": {
     "test": "tsc",
-    "build": "tsc",
+    "build": "tsc && rollup -c",
     "prepublish": "npm run build",
     "start": "tsc -w"
   },
@@ -29,6 +30,7 @@
   },
   "homepage": "https://github.com/tomwayson/esri-loader#readme",
   "devDependencies": {
+    "rollup": "^0.41.6",
     "typescript": "^2.0.10"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+export default {
+  entry: 'src/esri-loader.js',
+  format: 'umd',
+  dest: 'esri-loader.js',
+  moduleName: 'esriLoader',
+  exports: 'named'
+};

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -64,3 +64,9 @@ export function dojoRequire(modules: string[], callback: Function) {
     }
   }
 }
+
+export default {
+  isLoaded,
+  bootstrap,
+  dojoRequire
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es5",
-    "module": "commonjs",
+    "module": "es2015",
     "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -10,7 +10,7 @@
     "noImplicitAny": false
   },
   "files": [
-    "index.ts"
+    "src/esri-loader.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
use rollup to create umd build w/ global ('esriLoader')
move source to src folder and rename to esri-loader
added CHANGELOG

resolves #11 (I hope)
