### PR TITLE
check is esri-loader script has been loaded

### DIFF
--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -6,7 +6,7 @@ function getScript () {
 // has ArcGIS API been loaded on the page yet?
 export function isLoaded() {
   // would like to just use window.require, but fucking typescript
-  return typeof window['require'] !== 'undefined';
+  return typeof window['require'] !== 'undefined' && getScript();
 }
 
 // load the ArcGIS API on the page

--- a/test/esri-loader.spec.js
+++ b/test/esri-loader.spec.js
@@ -3,6 +3,8 @@ describe('esri-loader', function () {
     beforeEach(function() {
       // remove previously stubbed require function
       delete window.require;
+      // esri-loader script has not yet been loaded
+      document.querySelector = jasmine.createSpy('querySelector').and.returnValue(null);
     });
     it('isLoaded should be false', function () {
       expect(esriLoader.isLoaded())
@@ -69,6 +71,8 @@ describe('esri-loader', function () {
         actualModuleNames = names;
         callback();
       };
+      var esriLoaderScript = document.createElement('script');
+      document.querySelector = jasmine.createSpy('querySelector').and.returnValue(esriLoaderScript);
       spyOn(context, 'requireCallback');
       esriLoader.dojoRequire(expectedModuleNames, context.requireCallback);
     });


### PR DESCRIPTION
Currently the `isLoaded()` function is only checking if the `require` function existed.  This is causing an issue when using the `esri-loader` module in Electron because this ends up getting evaluated on a process running in NodeJS and therefor the API for `require` is different.  By adding a check for if the `esri-loader` script has been loaded if pushes this evaluation into the browser and Electron no longer throws an error.